### PR TITLE
Bump default version to 2.0.0. 

### DIFF
--- a/src/main/java/io/qameta/allure/bamboo/AllureBuildCompleteAction.java
+++ b/src/main/java/io/qameta/allure/bamboo/AllureBuildCompleteAction.java
@@ -6,7 +6,6 @@ import com.atlassian.bamboo.chains.ChainExecution;
 import com.atlassian.bamboo.chains.ChainResultsSummary;
 import com.atlassian.bamboo.chains.plugins.PostChainAction;
 import com.atlassian.bamboo.v2.build.BaseConfigurablePlugin;
-import com.google.common.io.Files;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.Map;
 
+import static com.google.common.io.Files.createTempDir;
 import static io.qameta.allure.bamboo.AllureBuildResult.allureBuildResult;
 import static io.qameta.allure.bamboo.util.ExceptionUtil.stackTraceToString;
 import static java.util.Optional.ofNullable;
@@ -50,8 +50,8 @@ public class AllureBuildCompleteAction extends BaseConfigurablePlugin implements
         if (!allureEnabled || (isEnabledForFailedOnly && !chainResultsSummary.isFailed())) {
             return;
         }
-        final File artifactsTempDir = Files.createTempDir();
-        final File allureReportDir = Files.createTempDir();
+        final File artifactsTempDir = createTempDir();
+        final File allureReportDir = new File(createTempDir(), "report");
         final Map<String, String> customBuildData = chainResultsSummary.getCustomBuildData();
         try {
             final String executable = ofNullable(buildConfig.getExecutable()).orElseGet(() -> {

--- a/src/main/java/io/qameta/allure/bamboo/AllureExecutable.java
+++ b/src/main/java/io/qameta/allure/bamboo/AllureExecutable.java
@@ -4,12 +4,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.LinkedList;
 
 import static java.util.Arrays.asList;
-import static org.apache.commons.io.FileUtils.forceMkdir;
 
 class AllureExecutable {
     private static final Logger LOGGER = LoggerFactory.getLogger(AllureExecutable.class);
@@ -25,8 +23,7 @@ class AllureExecutable {
     @Nonnull
     AllureGenerateResult generate(Path sourceDir, Path targetDir) {
         try {
-            forceMkdir(targetDir.toFile());
-            final LinkedList<String> args = new LinkedList<>(asList("generate", "-c", "-o", targetDir.toString(), sourceDir.toString()));
+            final LinkedList<String> args = new LinkedList<>(asList("generate", "-o", targetDir.toString(), sourceDir.toString()));
             String output;
             if (cmdLine.isUnix() && cmdLine.hasCommand(BASH_CMD)) {
                 args.addFirst(cmdPath.toString());
@@ -36,7 +33,7 @@ class AllureExecutable {
             }
             LOGGER.info(output);
             return cmdLine.parseGenerateOutput(output);
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new RuntimeException("Failed to generate allure report", e);
         }
     }

--- a/src/main/java/io/qameta/allure/bamboo/AllureExecutable.java
+++ b/src/main/java/io/qameta/allure/bamboo/AllureExecutable.java
@@ -26,7 +26,7 @@ class AllureExecutable {
     AllureGenerateResult generate(Path sourceDir, Path targetDir) {
         try {
             forceMkdir(targetDir.toFile());
-            final LinkedList<String> args = new LinkedList<>(asList("generate", "-o", targetDir.toString(), "-v", sourceDir.toString()));
+            final LinkedList<String> args = new LinkedList<>(asList("generate", "-c", "-o", targetDir.toString(), sourceDir.toString()));
             String output;
             if (cmdLine.isUnix() && cmdLine.hasCommand(BASH_CMD)) {
                 args.addFirst(cmdPath.toString());

--- a/src/main/java/io/qameta/allure/bamboo/AllureExecutableProvider.java
+++ b/src/main/java/io/qameta/allure/bamboo/AllureExecutableProvider.java
@@ -12,9 +12,9 @@ import static java.util.Objects.requireNonNull;
 import static java.util.regex.Pattern.compile;
 
 public class AllureExecutableProvider {
-    static final String DEFAULT_VERSION = "2.0-BETA6";
+    static final String DEFAULT_VERSION = "2.0.0";
     static final String DEFAULT_PATH = "/tmp/allure-executable";
-    private static final Pattern EXEC_NAME_PATTERN = compile(".+([0-9\\.]{3,}[a-zA-Z0-9\\-]*)$");
+    private static final Pattern EXEC_NAME_PATTERN = compile("[^\\d]*(\\d[0-9\\.]{2,}[a-zA-Z0-9\\-]*)$");
 
     private final BambooExecutablesManager bambooExecutablesManager;
     private final AllureDownloader allureDownloader;

--- a/src/test/java/io/qameta/allure/bamboo/AllureDownloaderTest.java
+++ b/src/test/java/io/qameta/allure/bamboo/AllureDownloaderTest.java
@@ -35,8 +35,15 @@ public class AllureDownloaderTest {
     }
 
     @Test
-    public void itShouldDownloadAndExtractAllure() throws Exception {
+    public void itShouldDownloadAndExtractAllureBeta() throws Exception {
         downloader.downloadAndExtractAllureTo(homeDir, "2.0-BETA5");
+
+        assertTrue(Paths.get(homeDir, "bin", "allure").toFile().exists());
+    }
+
+    @Test
+    public void itShouldDownloadAndExtractAllureRelease() throws Exception {
+        downloader.downloadAndExtractAllureTo(homeDir, "2.0.0");
 
         assertTrue(Paths.get(homeDir, "bin", "allure").toFile().exists());
     }

--- a/src/test/java/io/qameta/allure/bamboo/AllureExecutableProviderTest.java
+++ b/src/test/java/io/qameta/allure/bamboo/AllureExecutableProviderTest.java
@@ -50,7 +50,19 @@ public class AllureExecutableProviderTest {
     }
 
     @Test
-    public void itShouldProvideTheGivenVersionWithoutMilestone() throws Exception {
+    public void itShouldProvideTheGivenVersionWithFullSemverWithoutName() throws Exception {
+        provide("2.0.0");
+        verify(downloader).downloadAndExtractAllureTo(homeDir, "2.0.0");
+    }
+
+    @Test
+    public void itShouldProvideTheGivenVersionWithFullSemverWithoutMilestone() throws Exception {
+        provide("Allure 2.0.0");
+        verify(downloader).downloadAndExtractAllureTo(homeDir, "2.0.0");
+    }
+
+    @Test
+    public void itShouldProvideTheGivenVersionWithMajorMinorWithoutMilestone() throws Exception {
         provide("Allure 2.0");
         verify(downloader).downloadAndExtractAllureTo(homeDir, "2.0");
     }
@@ -77,7 +89,7 @@ public class AllureExecutableProviderTest {
         when(cmdLine.hasCommand(allureBatCmdPath.toString())).thenReturn(true);
         when(cmdLine.isWindows()).thenReturn(true);
 
-        final Optional<AllureExecutable> res = provide("Allure 2.0");
+        final Optional<AllureExecutable> res = provide("Allure 2.0.0");
 
         assertThat(res.isPresent(), equalTo(true));
         assertThat(res.get().getCmdPath(), equalTo(allureBatCmdPath));

--- a/src/test/java/io/qameta/allure/bamboo/AllureExecutableTest.java
+++ b/src/test/java/io/qameta/allure/bamboo/AllureExecutableTest.java
@@ -43,7 +43,7 @@ public class AllureExecutableTest {
 
         executable.generate(fromDir, toDir);
 
-        verify(cmdLine).runCommand("/bin/bash", path.toString(), "generate", "-o", toDir.toString(), "-v", fromDir.toString());
+        verify(cmdLine).runCommand("/bin/bash", path.toString(), "generate", "-c", "-o", toDir.toString(), fromDir.toString());
     }
 
     @Test
@@ -53,7 +53,7 @@ public class AllureExecutableTest {
 
         executable.generate(fromDir, toDir);
 
-        verify(cmdLine).runCommand(path.toString(), "generate", "-o", toDir.toString(), "-v", fromDir.toString());
+        verify(cmdLine).runCommand(path.toString(), "generate", "-c", "-o", toDir.toString(), fromDir.toString());
     }
 
     @Test
@@ -62,7 +62,7 @@ public class AllureExecutableTest {
 
         executable.generate(fromDir, toDir);
 
-        verify(cmdLine).runCommand(path.toString(), "generate", "-o", toDir.toString(), "-v", fromDir.toString());
+        verify(cmdLine).runCommand(path.toString(), "generate", "-c", "-o", toDir.toString(), fromDir.toString());
 
     }
 }

--- a/src/test/java/io/qameta/allure/bamboo/AllureExecutableTest.java
+++ b/src/test/java/io/qameta/allure/bamboo/AllureExecutableTest.java
@@ -43,7 +43,7 @@ public class AllureExecutableTest {
 
         executable.generate(fromDir, toDir);
 
-        verify(cmdLine).runCommand("/bin/bash", path.toString(), "generate", "-c", "-o", toDir.toString(), fromDir.toString());
+        verify(cmdLine).runCommand("/bin/bash", path.toString(), "generate", "-o", toDir.toString(), fromDir.toString());
     }
 
     @Test
@@ -53,7 +53,7 @@ public class AllureExecutableTest {
 
         executable.generate(fromDir, toDir);
 
-        verify(cmdLine).runCommand(path.toString(), "generate", "-c", "-o", toDir.toString(), fromDir.toString());
+        verify(cmdLine).runCommand(path.toString(), "generate", "-o", toDir.toString(), fromDir.toString());
     }
 
     @Test
@@ -62,7 +62,7 @@ public class AllureExecutableTest {
 
         executable.generate(fromDir, toDir);
 
-        verify(cmdLine).runCommand(path.toString(), "generate", "-c", "-o", toDir.toString(), fromDir.toString());
+        verify(cmdLine).runCommand(path.toString(), "generate", "-o", toDir.toString(), fromDir.toString());
 
     }
 }


### PR DESCRIPTION
Bump default Allure executable version to 2.0.0.
Bugfix: Fix version recognition regex to support full semver signature