### PR TITLE
Add the ability to store allure reports locally by default

### DIFF
--- a/src/main/java/io/qameta/allure/bamboo/AllureConstants.java
+++ b/src/main/java/io/qameta/allure/bamboo/AllureConstants.java
@@ -35,6 +35,7 @@ final class AllureConstants {
     static String ALLURE_CONFIG_DOWNLOAD_ENABLED = "custom.allure.config.download.enabled";
     static String ALLURE_CONFIG_ENABLED_BY_DEFAULT = "custom.allure.config.enabled.default";
     static String ALLURE_CONFIG_DOWNLOAD_URL = "custom.allure.config.download.url";
+    static String ALLURE_CONFIG_LOCAL_STORAGE = "custom.allure.config.local.storage";
 
     private AllureConstants() {
     }

--- a/src/main/java/io/qameta/allure/bamboo/AllureGlobalConfig.java
+++ b/src/main/java/io/qameta/allure/bamboo/AllureGlobalConfig.java
@@ -1,32 +1,38 @@
 package io.qameta.allure.bamboo;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.io.Serializable;
 import java.util.Map;
 
-import static io.qameta.allure.bamboo.AllureConstants.ALLURE_CONFIG_DOWNLOAD_URL;
 import static io.qameta.allure.bamboo.AllureConstants.ALLURE_CONFIG_DOWNLOAD_ENABLED;
+import static io.qameta.allure.bamboo.AllureConstants.ALLURE_CONFIG_DOWNLOAD_URL;
 import static io.qameta.allure.bamboo.AllureConstants.ALLURE_CONFIG_ENABLED_BY_DEFAULT;
+import static io.qameta.allure.bamboo.AllureConstants.ALLURE_CONFIG_LOCAL_STORAGE;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static java.lang.Boolean.parseBoolean;
 import static java.util.Optional.ofNullable;
+import static org.apache.commons.lang3.SystemUtils.getJavaIoTmpDir;
 import static org.sonatype.aether.util.StringUtils.isEmpty;
 
 class AllureGlobalConfig implements Serializable {
     private static final String DEFAULT_DOWNLOAD_BASE_URL = "https://dl.bintray.com/qameta/generic/io/qameta/allure/allure/";
+    public static final String DEFAULT_LOCAL_STORAGE_PATH = new File(getJavaIoTmpDir(), "allure-reports").getPath();
     private final boolean downloadEnabled;
     private final boolean enabledByDefault;
+    private final String localStoragePath;
     private final String downloadBaseUrl;
 
     AllureGlobalConfig() {
-        this(TRUE.toString(), FALSE.toString(), DEFAULT_DOWNLOAD_BASE_URL);
+        this(TRUE.toString(), FALSE.toString(), DEFAULT_DOWNLOAD_BASE_URL, DEFAULT_LOCAL_STORAGE_PATH);
     }
 
-    AllureGlobalConfig(String downloadEnabled, String enabledByDefault, String downloadBaseUrl) {
+    AllureGlobalConfig(String downloadEnabled, String enabledByDefault, String downloadBaseUrl, String localStoragePath) {
         this.downloadEnabled = isEmpty(downloadEnabled) ? TRUE : parseBoolean(downloadEnabled);
         this.enabledByDefault = isEmpty(enabledByDefault) ? FALSE : parseBoolean(enabledByDefault);
         this.downloadBaseUrl = isEmpty(downloadBaseUrl) ? DEFAULT_DOWNLOAD_BASE_URL : downloadBaseUrl;
+        this.localStoragePath = isEmpty(localStoragePath) ? DEFAULT_LOCAL_STORAGE_PATH : localStoragePath;
     }
 
 
@@ -34,7 +40,8 @@ class AllureGlobalConfig implements Serializable {
         return new AllureGlobalConfig(
                 getSingleValue(context, ALLURE_CONFIG_DOWNLOAD_ENABLED, TRUE.toString()),
                 getSingleValue(context, ALLURE_CONFIG_ENABLED_BY_DEFAULT, FALSE.toString()),
-                getSingleValue(context, ALLURE_CONFIG_DOWNLOAD_URL, null)
+                getSingleValue(context, ALLURE_CONFIG_DOWNLOAD_URL, null),
+                getSingleValue(context, ALLURE_CONFIG_LOCAL_STORAGE, null)
         );
     }
 
@@ -57,10 +64,14 @@ class AllureGlobalConfig implements Serializable {
         context.put(ALLURE_CONFIG_DOWNLOAD_ENABLED, isDownloadEnabled());
         context.put(ALLURE_CONFIG_ENABLED_BY_DEFAULT, isEnabledByDefault());
         context.put(ALLURE_CONFIG_DOWNLOAD_URL, getDownloadBaseUrl());
+        context.put(ALLURE_CONFIG_LOCAL_STORAGE, getLocalStoragePath());
     }
 
     String getDownloadBaseUrl() {
         return downloadBaseUrl;
     }
 
+    public String getLocalStoragePath() {
+        return localStoragePath;
+    }
 }

--- a/src/main/java/io/qameta/allure/bamboo/AllureSettingsManager.java
+++ b/src/main/java/io/qameta/allure/bamboo/AllureSettingsManager.java
@@ -6,6 +6,7 @@ import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 import static io.qameta.allure.bamboo.AllureConstants.ALLURE_CONFIG_DOWNLOAD_URL;
 import static io.qameta.allure.bamboo.AllureConstants.ALLURE_CONFIG_DOWNLOAD_ENABLED;
 import static io.qameta.allure.bamboo.AllureConstants.ALLURE_CONFIG_ENABLED_BY_DEFAULT;
+import static io.qameta.allure.bamboo.AllureConstants.ALLURE_CONFIG_LOCAL_STORAGE;
 
 public class AllureSettingsManager {
     private final PluginSettings settings;
@@ -18,12 +19,14 @@ public class AllureSettingsManager {
         final String downloadEnabled = (String) settings.get(ALLURE_CONFIG_DOWNLOAD_ENABLED);
         final String enableByDefault = (String) settings.get(ALLURE_CONFIG_ENABLED_BY_DEFAULT);
         final String downloadBaseUrl = (String) settings.get(ALLURE_CONFIG_DOWNLOAD_URL);
-        return new AllureGlobalConfig( downloadEnabled, enableByDefault, downloadBaseUrl);
+        final String localStorage = (String) settings.get(ALLURE_CONFIG_LOCAL_STORAGE);
+        return new AllureGlobalConfig( downloadEnabled, enableByDefault, downloadBaseUrl, localStorage);
     }
 
     void saveSettings(AllureGlobalConfig config) {
         settings.put(ALLURE_CONFIG_DOWNLOAD_ENABLED, String.valueOf(config.isDownloadEnabled()));
         settings.put(ALLURE_CONFIG_ENABLED_BY_DEFAULT, String.valueOf(config.isEnabledByDefault()));
         settings.put(ALLURE_CONFIG_DOWNLOAD_URL, String.valueOf(config.getDownloadBaseUrl()));
+        settings.put(ALLURE_CONFIG_LOCAL_STORAGE, String.valueOf(config.getLocalStoragePath()));
     }
 }

--- a/src/main/java/io/qameta/allure/bamboo/ConfigureAllureReportAction.java
+++ b/src/main/java/io/qameta/allure/bamboo/ConfigureAllureReportAction.java
@@ -30,6 +30,9 @@ public class ConfigureAllureReportAction extends GlobalAdminAction implements Pr
         if (!valuesMap.containsKey(AllureConstants.ALLURE_CONFIG_DOWNLOAD_URL)) {
             addActionError(getText("allure.config.download.url.error.required"));
         }
+        if (!valuesMap.containsKey(AllureConstants.ALLURE_CONFIG_LOCAL_STORAGE)) {
+            addActionError(getText("allure.config.download.local.storage.required"));
+        }
     }
 
     private AllureGlobalConfig getAllureConfig() {

--- a/src/main/resources/allure-bamboo.properties
+++ b/src/main/resources/allure-bamboo.properties
@@ -37,5 +37,7 @@ custom.allure.config.executable.label=Allure executable (home dir)
 allure.config.download.enabled.label=Download if no executable present
 allure.config.download.url.label=Allure binary base url
 allure.config.download.url.error.required=Allure binary base url is required
+allure.config.local.storage.label=Allure local storage
+allure.config.local.storage.label.required=Allure local storage is required
 build.allure.title=Allure Report
 buildResult.allure.title=Allure Report

--- a/src/main/resources/templates/editAllureReportConfig.ftl
+++ b/src/main/resources/templates/editAllureReportConfig.ftl
@@ -23,6 +23,8 @@
         [@ww.checkbox labelKey='allure.config.enabled.default.label' name='custom.allure.config.enabled.default' toggle='true' /]
 
         [@ww.textfield labelKey="allure.config.download.url.label" name="custom.allure.config.download.url" required="true"/]
+
+        [@ww.textfield labelKey="allure.config.local.storage.label" name="custom.allure.config.local.storage" required="true"/]
     [/@ww.form]
 </body>
 </html>


### PR DESCRIPTION
1. Add the local storage configuration option:
<img src="https://ibin.co/w800/3NY4oal1dPjk.png" width="100%"/>

2. Bamboo remote artifact handler (the default one) is now supported:
<img src="https://ibin.co/3NY5CwdzD9DU.png" width="100%"/>