### PR TITLE
Clean old Allure report directory if already exists

### DIFF
--- a/src/main/java/io/qameta/allure/bamboo/AllureArtifactsManager.java
+++ b/src/main/java/io/qameta/allure/bamboo/AllureArtifactsManager.java
@@ -64,6 +64,7 @@ import static io.qameta.allure.bamboo.util.ExceptionUtil.stackTraceToString;
 import static java.lang.Integer.parseInt;
 import static java.util.Optional.ofNullable;
 import static javax.ws.rs.core.UriBuilder.fromPath;
+import static org.apache.commons.io.FileUtils.deleteQuietly;
 import static org.apache.commons.io.FileUtils.moveDirectory;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.codehaus.plexus.util.FileUtils.copyDirectory;
@@ -181,6 +182,9 @@ public class AllureArtifactsManager {
                     final String planKey = chain.getPlanKey().getKey();
                     final String buildNumber = String.valueOf(summary.getBuildNumber());
                     final File destDir = Paths.get(settings.getLocalStoragePath(), planKey, buildNumber).toFile();
+                    if (destDir.exists()) {
+                        deleteQuietly(destDir);
+                    }
                     moveDirectory(reportDir, destDir);
                     return Optional.of(allureBuildResult(true, null)
                             .withHandlerClass(artifactHandler.getClass().getName()));

--- a/src/main/java/io/qameta/allure/bamboo/AllureArtifactsManager.java
+++ b/src/main/java/io/qameta/allure/bamboo/AllureArtifactsManager.java
@@ -47,6 +47,7 @@ import javax.ws.rs.core.UriBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
@@ -72,6 +73,7 @@ import static org.codehaus.plexus.util.FileUtils.copyURLToFile;
 
 public class AllureArtifactsManager {
     private static final Logger LOGGER = Logger.getLogger(AllureArtifactsManager.class);
+    private static final String REPORTS_SUBDIR = "allure-reports";
 
     private final PluginAccessor pluginAccessor;
     private final ArtifactHandlersService artifactHandlersService;
@@ -128,8 +130,7 @@ public class AllureArtifactsManager {
 
     @Nullable
     private String getLocalStorageURL(String planKeyString, String buildNumber, String filePath) {
-        final AllureGlobalConfig settings = settingsManager.getSettings();
-        final File file = Paths.get(settings.getLocalStoragePath(), planKeyString, buildNumber).resolve(filePath).toFile();
+        final File file = getLocalStoragePath(planKeyString, buildNumber).resolve(filePath).toFile();
         final String fullPath = (file.isDirectory()) ? new File(file, "index.html").getAbsolutePath() : file.getAbsolutePath();
         return String.format("file://%s", fullPath);
     }
@@ -178,10 +179,9 @@ public class AllureArtifactsManager {
                     continue;
                 }
                 if (isAgentArtifactHandler(artifactHandler)) {
-                    final AllureGlobalConfig settings = settingsManager.getSettings();
                     final String planKey = chain.getPlanKey().getKey();
                     final String buildNumber = String.valueOf(summary.getBuildNumber());
-                    final File destDir = Paths.get(settings.getLocalStoragePath(), planKey, buildNumber).toFile();
+                    final File destDir = getLocalStoragePath(planKey, buildNumber).toFile();
                     if (destDir.exists()) {
                         deleteQuietly(destDir);
                     }
@@ -218,6 +218,9 @@ public class AllureArtifactsManager {
         return Optional.empty();
     }
 
+    private Path getLocalStoragePath(String planKey, String buildNumber) {
+        return Paths.get(settingsManager.getSettings().getLocalStoragePath(), REPORTS_SUBDIR, planKey, buildNumber);
+    }
 
     private void downloadAllArtifactsTo(ArtifactLinkDataProvider dataProvider, File tempDir, String startFrom) {
         for (ArtifactFileData data : dataProvider.listObjects(startFrom)) {

--- a/src/main/java/io/qameta/allure/bamboo/AllureBuildCompleteAction.java
+++ b/src/main/java/io/qameta/allure/bamboo/AllureBuildCompleteAction.java
@@ -5,6 +5,7 @@ import com.atlassian.bamboo.chains.Chain;
 import com.atlassian.bamboo.chains.ChainExecution;
 import com.atlassian.bamboo.chains.ChainResultsSummary;
 import com.atlassian.bamboo.chains.plugins.PostChainAction;
+import com.atlassian.bamboo.resultsummary.ResultsSummaryManager;
 import com.atlassian.bamboo.v2.build.BaseConfigurablePlugin;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -28,16 +29,19 @@ public class AllureBuildCompleteAction extends BaseConfigurablePlugin implements
     private final AllureSettingsManager settingsManager;
     private final AllureArtifactsManager artifactsManager;
     private final BambooExecutablesManager executablesManager;
+    private final ResultsSummaryManager resulsSummaryManager;
 
 
     public AllureBuildCompleteAction(AllureExecutableProvider allureExecutable,
                                      AllureSettingsManager settingsManager,
                                      AllureArtifactsManager artifactsManager,
-                                     BambooExecutablesManager executablesManager) {
+                                     BambooExecutablesManager executablesManager,
+                                     ResultsSummaryManager resultsSummaryManager) {
         this.allureExecutable = allureExecutable;
         this.settingsManager = settingsManager;
         this.artifactsManager = artifactsManager;
         this.executablesManager = executablesManager;
+        this.resulsSummaryManager = resultsSummaryManager;
     }
 
     @Override

--- a/src/main/java/io/qameta/allure/bamboo/AllureCommandLineSupport.java
+++ b/src/main/java/io/qameta/allure/bamboo/AllureCommandLineSupport.java
@@ -1,5 +1,6 @@
 package io.qameta.allure.bamboo;
 
+import org.buildobjects.process.ProcBuilder;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Paths;
@@ -7,15 +8,18 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.lang.Integer.parseInt;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.commons.lang3.SystemUtils.IS_OS_UNIX;
 import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
-import static org.buildobjects.process.ProcBuilder.run;
 
 public class AllureCommandLineSupport {
     private static final Pattern RESULT_TC_COUNT_REGEX = Pattern.compile(".+Found (\\d+) test cases.+", Pattern.DOTALL);
+    private static final int GENERATE_TIMEOUT_MS = (int) SECONDS.toMillis(60);
 
     String runCommand(String cmd, String... args) {
-        return run(cmd, args);
+        return new ProcBuilder(cmd)
+                .withArgs(args).withTimeoutMillis(GENERATE_TIMEOUT_MS)
+                .run().getOutputString();
     }
 
     @NotNull

--- a/src/test/java/io/qameta/allure/bamboo/AllureExecutableProviderTest.java
+++ b/src/test/java/io/qameta/allure/bamboo/AllureExecutableProviderTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Paths;
 import java.util.Optional;
 
 import static io.qameta.allure.bamboo.AllureExecutableProvider.DEFAULT_VERSION;
+import static io.qameta.allure.bamboo.AllureExecutableProvider.getAllureSubDir;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
@@ -22,6 +23,7 @@ import static org.mockito.junit.MockitoJUnit.rule;
 public class AllureExecutableProviderTest {
 
     private final String homeDir = "/home/allure";
+    private final String binaryDir = Paths.get(this.homeDir, getAllureSubDir()).toString();
     @Rule
     public MockitoRule mockitoRule = rule();
     @Mock
@@ -39,38 +41,38 @@ public class AllureExecutableProviderTest {
     @Before
     public void setUp() throws Exception {
         config = new AllureGlobalConfig();
-        allureCmdPath = Paths.get(homeDir, "bin", "allure");
-        allureBatCmdPath = Paths.get(homeDir, "bin", "allure.bat");
+        allureCmdPath = Paths.get(binaryDir, "bin", "allure");
+        allureBatCmdPath = Paths.get(binaryDir, "bin", "allure.bat");
     }
 
     @Test
     public void itShouldProvideDefaultVersion() throws Exception {
         provide("Allure WITHOUT VERSION");
-        verify(downloader).downloadAndExtractAllureTo(homeDir, DEFAULT_VERSION);
+        verify(downloader).downloadAndExtractAllureTo(binaryDir, DEFAULT_VERSION);
     }
 
     @Test
     public void itShouldProvideTheGivenVersionWithFullSemverWithoutName() throws Exception {
         provide("2.0.0");
-        verify(downloader).downloadAndExtractAllureTo(homeDir, "2.0.0");
+        verify(downloader).downloadAndExtractAllureTo(binaryDir, "2.0.0");
     }
 
     @Test
     public void itShouldProvideTheGivenVersionWithFullSemverWithoutMilestone() throws Exception {
         provide("Allure 2.0.0");
-        verify(downloader).downloadAndExtractAllureTo(homeDir, "2.0.0");
+        verify(downloader).downloadAndExtractAllureTo(binaryDir, "2.0.0");
     }
 
     @Test
     public void itShouldProvideTheGivenVersionWithMajorMinorWithoutMilestone() throws Exception {
         provide("Allure 2.0");
-        verify(downloader).downloadAndExtractAllureTo(homeDir, "2.0");
+        verify(downloader).downloadAndExtractAllureTo(binaryDir, "2.0");
     }
 
     @Test
     public void itShouldProvideTheGivenVersionWithMilestone() throws Exception {
         provide("Allure 2.0-BETA4");
-        verify(downloader).downloadAndExtractAllureTo(homeDir, "2.0-BETA4");
+        verify(downloader).downloadAndExtractAllureTo(binaryDir, "2.0-BETA4");
     }
 
     @Test


### PR DESCRIPTION
It is necessary for restarted builds, otherwise, you would get the following exception:

```
org.apache.commons.io.FileExistsException: Destination '/.../allure-reports/BUILD/3' already exists
```

NB: this is required only for Bamboo remote artifact handler