### PR TITLE
Add Slf4j version to pom to prevent incompatibilities (refs #35)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,13 @@
         <url>https://github.com/allure-framework</url>
     </organization>
     <properties>
-        <amps.version>6.2.11</amps.version>
+        <amps.version>6.3.0</amps.version>
         <bamboo.version>5.10.3</bamboo.version>
         <bamboo.data.version>5.10.3</bamboo.data.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
+        <slf4j.version>1.7.21</slf4j.version>
         <compiler.version>1.8</compiler.version>
     </properties>
 
@@ -51,6 +52,18 @@
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
             <version>1.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.plugin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,9 @@
         <url>https://github.com/allure-framework</url>
     </organization>
     <properties>
-        <amps.version>6.3.0</amps.version>
+        <amps.version>6.3.7</amps.version>
         <bamboo.version>5.10.3</bamboo.version>
-        <bamboo.data.version>5.10.3</bamboo.data.version>
+        <bamboo.data.version>${bamboo.version}</bamboo.data.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>

--- a/src/main/java/io/qameta/allure/bamboo/AllureDownloader.java
+++ b/src/main/java/io/qameta/allure/bamboo/AllureDownloader.java
@@ -70,7 +70,7 @@ class AllureDownloader {
 
     private URL buildAllureDownloadUrl(String version) throws MalformedURLException {
         return fromPath(settingsManager.getSettings().getDownloadBaseUrl())
-                .path(Paths.get(version, "allure-" + version + ".zip").toString())
+                .path(version + "/" + "allure-" + version + ".zip")
                 .build().toURL();
     }
 }

--- a/src/main/java/io/qameta/allure/bamboo/AllureDownloader.java
+++ b/src/main/java/io/qameta/allure/bamboo/AllureDownloader.java
@@ -59,7 +59,7 @@ class AllureDownloader {
         try {
             final URL url = buildAllureDownloadUrl(version);
             final Path downloadToFile = createTempFile("allure", "zip");
-            LOGGER.info("Downloading allure.zip from " + url + " to " + downloadToFile);
+            LOGGER.info("Downloading allure.zip from {} to {}", url, downloadToFile);
             copyURLToFile(url, downloadToFile.toFile(), CONN_TIMEOUT_MS, DOWNLOAD_TIMEOUT_MS);
             return Optional.of(downloadToFile);
         } catch (IOException e) {

--- a/src/main/java/io/qameta/allure/bamboo/AllureDownloader.java
+++ b/src/main/java/io/qameta/allure/bamboo/AllureDownloader.java
@@ -35,7 +35,7 @@ class AllureDownloader {
     Optional<Path> downloadAndExtractAllureTo(String allureHomeDir, String version) {
         return downloadAllure(version).map(zipFilePath -> {
             try {
-                LOGGER.info("Extracting file " + zipFilePath + " to " + allureHomeDir + "...");
+                LOGGER.info("Extracting file {} to {}...", zipFilePath, allureHomeDir);
                 final String extractedDirName = "allure-" + version;
                 final File homeDir = new File(allureHomeDir);
                 final Path extracteDir = zipFilePath.getParent();

--- a/src/main/java/io/qameta/allure/bamboo/BambooExecutablesManager.java
+++ b/src/main/java/io/qameta/allure/bamboo/BambooExecutablesManager.java
@@ -6,6 +6,8 @@ import com.atlassian.bamboo.v2.build.agent.capability.CapabilityImpl;
 import com.atlassian.bamboo.v2.build.agent.capability.CapabilitySetManager;
 import com.atlassian.bamboo.v2.build.agent.capability.LocalCapabilitySet;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
@@ -20,6 +22,7 @@ import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 
 public class BambooExecutablesManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BambooExecutablesManager.class);
     private final CapabilitySetManager capabilitySetManager;
 
     public BambooExecutablesManager(CapabilitySetManager capabilitySetManager) {
@@ -42,10 +45,14 @@ public class BambooExecutablesManager {
     }
 
     Optional<String> getExecutableByName(String executableName) {
+        LOGGER.debug("Trying to find a capability by executable name '{}'", executableName);
         return getCapabilityKeys().stream()
                 .filter(capKey -> {
                     final String[] strings = capKey.split("\\.", 4);
-                    return strings.length == 4 && executableName.equals(strings[3]);
+                    final boolean matches = strings.length == 4 && executableName.equals(strings[3]);
+                    LOGGER.debug("Checking key '{}' to matches executable name '{}'={}...",
+                            capKey, executableName, matches);
+                    return matches;
                 })
                 .findFirst()
                 .map(this::getCapability)


### PR DESCRIPTION
This PR specifies the version of Slf4j directly in the POM, so there should not be logging incompatibility issues anymore.