### PR TITLE
Removed 1 unnecessary stubbing in AllureExecutableTest.java

### DIFF
--- a/src/test/java/io/qameta/allure/bamboo/AllureExecutableTest.java
+++ b/src/test/java/io/qameta/allure/bamboo/AllureExecutableTest.java
@@ -26,7 +26,6 @@ import java.nio.file.Paths;
 
 import static com.google.common.io.Files.createTempDir;
 import static java.util.Collections.singleton;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.junit.MockitoJUnit.rule;
@@ -53,8 +52,6 @@ public class AllureExecutableTest {
         executable = new AllureExecutable(path, cmdLine);
         fromDir = createTempDir().toPath();
         toDir = createTempDir().toPath();
-        when(cmdLine.parseGenerateOutput(anyString()))
-                .thenReturn(new AllureGenerateResult("", true));
     }
 
     @Test


### PR DESCRIPTION
In our analysis of the project, we observed that the test `AllureExecutableTest.setUp` contains an unnecessary stubbing. 

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbing.