### PR TITLE
chore: use allure ci app for release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release
 run-name: Release ${{ inputs.releaseVersion }} (next ${{ inputs.nextVersion }}) by ${{ github.actor }}
 
-permissions: {}
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:
@@ -16,19 +17,30 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      GIT_COMMIT_AUTHOR_EMAIL: ${{ vars.ALLURE_CI_APP_USER_ID }}+${{ vars.ALLURE_CI_APP_SLUG }}[bot]@users.noreply.github.com
+      GIT_COMMIT_AUTHOR_NAME: ${{ vars.ALLURE_CI_APP_SLUG }}[bot]
     steps:
-      - name: Check release version
+      - name: "Check release version"
         run: |
           echo "${{ github.event.inputs.releaseVersion }}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?$'
 
-      - name: Check next version
+      - name: "Check next version"
         run: |
           echo "${{ github.event.inputs.nextVersion }}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'
+
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.ALLURE_CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ALLURE_CI_APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.ref_name }}
-          token: ${{ secrets.QAMETA_CI }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -37,31 +49,31 @@ jobs:
           java-version: '17'
           cache: 'maven'
 
-      - name: Configure CI Git User
+      - name: "Configure CI Git User"
         run: |
-          git config --global user.name qameta-ci
-          git config --global user.email qameta-ci@qameta.io
+          git config --global user.name "${GIT_COMMIT_AUTHOR_NAME}"
+          git config --global user.email "${GIT_COMMIT_AUTHOR_EMAIL}"
 
-      - name: Set release version
+      - name: "Set release version"
         run: |
           ./mvnw versions:set -DnewVersion=${{ github.event.inputs.releaseVersion }}
 
-      - name: Commit release version and create tag
+      - name: "Commit release version and create tag"
         run: |
           git commit -am "release ${{ github.event.inputs.releaseVersion }}"
           git tag ${{ github.event.inputs.releaseVersion }}
           git push origin ${{ github.event.inputs.releaseVersion }}
 
-      - name: Set next development version
+      - name: "Set next development version"
         run: |
           ./mvnw versions:set -DnewVersion=${{ github.event.inputs.nextVersion }}-SNAPSHOT-j17
 
-      - name: Commit next development version and push it
+      - name: "Commit next development version and push it"
         run: |
           git commit -am "set next development version ${{ github.event.inputs.nextVersion }}"
           git push origin HEAD:${{ github.ref_name }}
 
-      - name: Publish GitHub Release
+      - name: "Publish Github Release"
         uses: octokit/request-action@v2.x
         with:
           route: POST /repos/${{ github.repository }}/releases
@@ -69,4 +81,4 @@ jobs:
           generate_release_notes: true
           target_commitish: ${{ github.ref_name }}
         env:
-          GITHUB_TOKEN: ${{ secrets.QAMETA_CI }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Bamboo 10 compatibility (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

The release workflow now uses the Allure CI GitHub App instead of the legacy QAMETA_CI personal access token. Release tagging, version bump commits, and GitHub release creation continue to run under the dedicated automation identity.

#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
