### PR TITLE
Fix Allure report settings and custom branding edge cases

### DIFF
--- a/src/main/java/io/qameta/allure/bamboo/info/AllurePlugins.java
+++ b/src/main/java/io/qameta/allure/bamboo/info/AllurePlugins.java
@@ -15,10 +15,11 @@
  */
 package io.qameta.allure.bamboo.info;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class AllurePlugins {
-    private List<String> plugins;
+    private List<String> plugins = new ArrayList<>();
 
     public AllurePlugins(final List<String> plugins) {
         this.plugins = plugins;

--- a/src/main/java/io/qameta/allure/bamboo/util/FileStringReplacer.java
+++ b/src/main/java/io/qameta/allure/bamboo/util/FileStringReplacer.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class FileStringReplacer {
@@ -33,7 +34,7 @@ public final class FileStringReplacer {
                                      final String oldString,
                                      final String newString) throws IOException {
         String content = new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8);
-        content = content.replaceAll(oldString, newString);
+        content = content.replaceAll(oldString, Matcher.quoteReplacement(newString));
         Files.write(filePath, content.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -41,7 +42,7 @@ public final class FileStringReplacer {
                                      final @NotNull Pattern pattern,
                                      final String newString) throws IOException {
         String content = new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8);
-        content = pattern.matcher(content).replaceAll(newString);
+        content = pattern.matcher(content).replaceAll(Matcher.quoteReplacement(newString));
         Files.write(filePath, content.getBytes(StandardCharsets.UTF_8));
     }
 

--- a/src/main/resources/templates/editAllureReportConfig.ftl
+++ b/src/main/resources/templates/editAllureReportConfig.ftl
@@ -26,9 +26,9 @@ cancelUri='/admin/editAllureReportConfig.action'
 
     [@ww.checkbox labelKey='custom.allure.config.reports.cleanup.enabled.label' name='enabledReportsCleanup' toggle='false' /]
 
-    [@ww.textfield labelKey='custom.allure.config.download.url.label' name='localStoragePath' required='true'/]
+    [@ww.textfield labelKey='custom.allure.config.download.url.label' name='downloadBaseUrl' required='true'/]
 
-    [@ww.textfield labelKey='custom.allure.config.local.storage.label' name='downloadBaseUrl' required='true'/]
+    [@ww.textfield labelKey='custom.allure.config.local.storage.label' name='localStoragePath' required='true'/]
 [/@ww.form]
 </body>
 </html>

--- a/src/test/java/io/qameta/allure/bamboo/info/AllurePluginsTest.java
+++ b/src/test/java/io/qameta/allure/bamboo/info/AllurePluginsTest.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2016-2024 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.bamboo.info;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import org.junit.Test;
+
+import static io.qameta.allure.bamboo.TestSupport.attachText;
+import static io.qameta.allure.bamboo.TestSupport.step;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AllurePluginsTest {
+
+    private static final String PLUGIN = "custom-logo-plugin";
+
+    @Test
+    public void itShouldRegisterPluginOnFreshInstanceWithoutNpe() throws Exception {
+        final AllurePlugins plugins = new AllurePlugins();
+
+        final boolean added = plugins.registerPlugin(PLUGIN);
+
+        step("verify a fresh instance registered the plugin without a NullPointerException", () -> {
+            attachText("Registered plugins", String.valueOf(plugins.getPlugins()));
+            assertThat(added).isTrue();
+            assertThat(plugins.isRegistered(PLUGIN)).isTrue();
+            assertThat(plugins.getPlugins()).containsExactly(PLUGIN);
+        });
+    }
+
+    @Test
+    public void itShouldExposeEmptyListWhenConfigHasNoPluginsKey() throws Exception {
+        // Mirrors setCustomLogo reading an allure.yml distribution config that omits `plugins:`.
+        final AllurePlugins plugins = new YAMLMapper().readValue("{}", AllurePlugins.class);
+
+        step("verify a config without a plugins key yields a non-null, mutable list", () -> {
+            attachText("Parsed plugins", String.valueOf(plugins.getPlugins()));
+            assertThat(plugins.getPlugins()).isNotNull().isEmpty();
+            assertThat(plugins.registerPlugin(PLUGIN)).isTrue();
+            assertThat(plugins.getPlugins()).containsExactly(PLUGIN);
+        });
+    }
+}

--- a/src/test/java/io/qameta/allure/bamboo/util/FileStringReplacerTest.java
+++ b/src/test/java/io/qameta/allure/bamboo/util/FileStringReplacerTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 2016-2024 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.bamboo.util;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+import static io.qameta.allure.bamboo.TestSupport.attachText;
+import static io.qameta.allure.bamboo.TestSupport.step;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FileStringReplacerTest {
+
+    @Rule
+    public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void itShouldInsertReplacementLiterallyWhenItContainsRegexMetacharacters() throws Exception {
+        final String prefix = ".brand { background: ";
+        final String suffix = " }";
+        // Custom logo URLs and build names are user-controlled and can legitimately contain '$'
+        // (group reference) or '\' (escape); an unquoted replacement throws or corrupts the file.
+        final String replacement = "url(https://cdn.example.com/logo$1_v2\\final.svg)";
+
+        final Path cssFile = step("write a stylesheet containing a url('old') token", () -> {
+            final Path file = tempFolder.newFile("styles.css").toPath();
+            Files.write(file, (prefix + "url('old')" + suffix).getBytes(StandardCharsets.UTF_8));
+            return file;
+        });
+
+        step("replace the token with a value containing regex metacharacters", () ->
+                FileStringReplacer.replaceInFile(cssFile, Pattern.compile("url\\('.+'\\)"), replacement));
+
+        step("verify the metacharacters were written verbatim, not interpreted", () -> {
+            final String content = new String(Files.readAllBytes(cssFile), StandardCharsets.UTF_8);
+            attachText("Rewritten stylesheet", content);
+            assertThat(content).isEqualTo(prefix + replacement + suffix);
+        });
+    }
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Bamboo 10 compatibility (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->
This fixes the global Allure report configuration form so the download URL and local storage path fields save into the correct settings instead of being swapped.

It also makes custom branding more reliable: Allure configs without an existing plugins list can now register the custom logo plugin, and replacement values such as logo URLs or build names containing `$` or backslashes are written literally instead of failing or being corrupted.


#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2