### PR TITLE
fix release label excludes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,9 @@
 # release.yml
 
 changelog:
+  exclude:
+    labels:
+      - "pr:invalid"
   categories:
     - title: "🚀 New Features"
       labels:


### PR DESCRIPTION
## Summary
- exclude non-release PR labels from generated release notes
